### PR TITLE
feat(host): if outdir is provided log bytes sent/received per TCP port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,9 @@ pub struct Host {
     /// Vhost-user-vsock socket
     #[structopt(short = "u", long)]
     vhost_user_path: Option<PathBuf>,
+    /// Event source path.
+    #[structopt(short, long)]
+    outdir: Option<PathBuf>,
 }
 
 /// Guest request.


### PR DESCRIPTION
This PR adds a feature to vpnguin for logging how much data is sent across the vpn for TCP streams. The feature is optional and only enabled when vpnguin is pointed towards an output directory on the host. This can be useful for gathering statistics on how healthy guest services are when we interact with them.

Example output:
```
./runs/0/output$ head -n4 vpn_*_*
==> vpn_0.0.0.0_111 <==
bytes_to_guest,bytes_from_guest
0,0
0,0
44,36

==> vpn_0.0.0.0_53573 <==
bytes_to_guest,bytes_from_guest
0,0
25,0
14,0

==> vpn_0.0.0.0_80 <==
bytes_to_guest,bytes_from_guest
18,45
306,332
149,384
```