### PR TITLE
support specifying source address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ pub enum HostRequest {
         internal_address: SocketAddr,
         /// Transport.
         transport: Transport,
+        /// Source address (for spoofing).
+        source_address: SocketAddr,
     },
 }
 


### PR DESCRIPTION
This is the vpnguin side of adding support for spoofing source addresses in support of https://github.com/rehosting/penguin/issues/498

We do this by binding to that address in the guest code and then connecting/sending from that bound socket.