### PR TITLE
update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
           docker run --rm -v $PWD:/app -w /app ghcr.io/rehosting/embedded-toolchains_rust:latest /app/package.sh
 
       - name: Save package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: hypernvram
+          name: vpnguin
           path: vpn.tar.gz 
 
       - name: Create release


### PR DESCRIPTION
CI/CD builds failing due to
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```