### PR TITLE
Optimize Guest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-vsock = "0.6.0"
 tracing = "0"
-csv = "1.1"
+csv = "=1.3.0"
 tracing-subscriber = "0"
 csv-line = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
-bincode = "1"
-daemonize = "0"
+anyhow = "1.0.75"
+bincode = "1.3.3"
+daemonize = "0.5.0"
 lazy_static = "1"
 libc = "0"
 regex = "1"
-serde = { version = "1", features = ["derive"] }
-structopt = "0"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0.188", features = ["derive"] }
+serde_bytes = "0.11"
+structopt = "0.3.26"
+tokio = { version = "1.32.0", features = ["full"] }
 tokio-vsock = "0.6.0"
 tracing = "0"
 csv = "=1.3.0"

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -1,17 +1,21 @@
 //! Guest implementation.
 
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 
-use crate::{read_event, Guest, HostRequest, Transport};
+use crate::{read_event, write_event, Guest, HostRequest, UdpMuxPacket};
 use anyhow::{anyhow, Context, Result};
 use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncWriteExt, BufWriter, copy},
     net::{TcpSocket, TcpStream, UdpSocket},
+    select,
+    sync::mpsc,
 };
 use tokio_vsock::{VsockAddr, VsockListener, VsockStream};
 
 use tokio::time::{timeout, Duration};
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const UDP_CLIENT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Execute the guest endpoint.
 pub async fn execute(command: &Guest) -> Result<()> {
@@ -38,17 +42,17 @@ pub async fn execute(command: &Guest) -> Result<()> {
 }
 
 /// Process a vsock client.
-async fn process_client(mut vsock: VsockStream, peer_address: VsockAddr) -> Result<()> {
+async fn process_client(vsock: VsockStream, peer_address: VsockAddr) -> Result<()> {
     info!(peer = peer_address.to_string(), "processing client");
 
-    // Process the init event
-    let e: Option<HostRequest> = read_event(&mut vsock)
+    let (mut vsock_read, mut vsock_write) = tokio::io::split(vsock);
+
+    let e: Option<HostRequest> = read_event(&mut vsock_read)
         .await
         .context("unable to read init event")?;
     match e {
-        Some(HostRequest::Forward {
+        Some(HostRequest::ForwardTcp {
             mut internal_address,
-            transport: _transport @ Transport::Tcp,
             source_address,
         }) => {
             // Check for wildcard addresses and replace with localhost
@@ -63,9 +67,32 @@ async fn process_client(mut vsock: VsockStream, peer_address: VsockAddr) -> Resu
             };
             socket.bind(source_address)?;
             match timeout(CONNECTION_TIMEOUT, socket.connect(internal_address)).await {
-                Ok(Ok(stream)) => {
+                Ok(Ok(mut stream)) => {
                     info!("Successfully connected to {}", internal_address);
-                    proxy_tcp(vsock, peer_address, stream).await?;
+                    stream.set_nodelay(true)?;
+
+                    // split the TCP stream into read/write halves
+                    let (mut stream_read, mut stream_write) = stream.split();
+
+                    // create copy futures for both directions
+                    let client_to_server = copy(&mut vsock_read, &mut stream_write);
+                    let server_to_client = copy(&mut stream_read, &mut vsock_write);
+
+                    // pin them so select! can poll them
+                    tokio::pin!(client_to_server);
+                    tokio::pin!(server_to_client);
+
+                    // wait for either direction to finish (or error)
+                    tokio::select! {
+                        res = &mut client_to_server => {
+                            res.context("vsock -> stream copy failed")?;
+                        },
+                        res = &mut server_to_client => {
+                            res.context("stream -> vsock copy failed")?;
+                        },
+                    }
+
+                    debug!(peer = peer_address.to_string(), "Proxy operation completed");
                 },
                 Ok(Err(e)) => {
                     warn!("Failed to connect to {}: {}", internal_address, e);
@@ -78,19 +105,17 @@ async fn process_client(mut vsock: VsockStream, peer_address: VsockAddr) -> Resu
             }
         }
 
-        Some(HostRequest::Forward {
+        Some(HostRequest::ForwardUdpMux {
             mut internal_address,
-            transport: _transport @ Transport::Udp,
             source_address,
         }) => {
-            // Check for wildcard addresses and replace with localhost
             if internal_address.ip() == IpAddr::V4([0, 0, 0, 0].into()) {
                 internal_address.set_ip(IpAddr::V4([127, 0, 0, 1].into()));
             } else if internal_address.ip() == IpAddr::V6([0, 0, 0, 0, 0, 0, 0, 0].into()) {
                 internal_address.set_ip(IpAddr::V6([0, 0, 0, 0, 0, 0, 0, 1].into()));
             }
 
-            proxy_udp(vsock, peer_address, internal_address, source_address).await?;
+            proxy_udp_mux(vsock_read, vsock_write, peer_address, internal_address, source_address).await?;
         }
 
         None => {
@@ -113,9 +138,62 @@ async fn proxy_tcp(
     Ok(())
 }
 
-/// Proxy UDP.
-async fn proxy_udp(
-    mut vsock: VsockStream,
+/// Manages a single UDP client's session.
+async fn forward_udp_client_mux(
+    mut rx: mpsc::Receiver<Vec<u8>>,
+    reply_tx: mpsc::Sender<UdpMuxPacket>,
+    internal_address: SocketAddr,
+    source_address: SocketAddr,
+    client_addr: SocketAddr,
+) -> Result<()> {
+    let socket = UdpSocket::bind(source_address).await?;
+
+    let mut read_buf = vec![0u8; 8192];
+
+    loop {
+        select! {
+            biased;
+
+            Some(data) = rx.recv() => {
+                if let Err(e) = socket.send_to(&data, internal_address).await {
+                    error!(client = %client_addr, "Failed to send to internal service: {e}");
+                    break;
+                }
+            },
+
+            result = socket.recv(&mut read_buf) => {
+                match result {
+                    Ok(n) => {
+                        let data = read_buf[..n].to_vec();
+                        let packet = UdpMuxPacket {
+                            client_addr,
+                            data,
+                        };
+                        if reply_tx.send(packet).await.is_err() {
+                            debug!(client = %client_addr, "Reply channel closed, client task shutting down.");
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        error!(client = %client_addr, "Failed to recv from internal socket: {e}");
+                        break;
+                    }
+                }
+            },
+
+            _ = tokio::time::sleep(UDP_CLIENT_TIMEOUT) => {
+                debug!(client = %client_addr, "Client timed out, shutting down.");
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Manages the single vsock stream for all UDP clients.
+async fn proxy_udp_mux(
+    mut vsock_read: tokio::io::ReadHalf<VsockStream>,
+    vsock_write: tokio::io::WriteHalf<VsockStream>,
     peer_address: VsockAddr,
     internal_address: SocketAddr,
     source_address: SocketAddr,
@@ -123,48 +201,69 @@ async fn proxy_udp(
     debug!(
         peer = peer_address.to_string(),
         internal = internal_address.to_string(),
-        "forwarding udp datagrams"
+        "initializing multiplexed udp proxy"
     );
 
-    let mut buffer = [0u8; 8192];
-    let socket = UdpSocket::bind(source_address)
-        .await
-        .context("unable to bind udp socket")?;
+    let mut clients: HashMap<SocketAddr, mpsc::Sender<Vec<u8>>> = HashMap::new();
+    let (reply_tx, mut reply_rx) = mpsc::channel::<UdpMuxPacket>(256);
+
+    let mut vsock_write = BufWriter::new(vsock_write);
 
     loop {
-        debug!("reading client datagram");
-        let n = vsock
-            .read_u16()
-            .await
-            .context("unable to read client datagram size")? as _;
-        vsock
-            .read_exact(&mut buffer[..n])
-            .await
-            .context("unable to read client datagram")?;
-        debug!(
-            peer = peer_address.to_string(),
-            internal = internal_address.to_string(),
-            size = n,
-            "forwarding udp datagram"
-        );
-        socket
-            .send_to(&buffer[..n], &internal_address)
-            .await
-            .context("unable to write client datagram")?;
-        debug!("reading server datagram");
-        let n = socket
-            .recv(&mut buffer)
-            .await
-            .context("unable to read server datagram")?;
-        debug!("forwarding server datagram");
-        // TODO: Buffer this and similar to reduce syscalls if perf becomes an issue
-        vsock
-            .write_u16(n as _)
-            .await
-            .context("unable to write server datagram size")?;
-        vsock
-            .write_all(&buffer[..n])
-            .await
-            .context("unable to write server datagram")?;
+        select! {
+            result = read_event::<_, UdpMuxPacket>(&mut vsock_read) => {
+                match result {
+                    Ok(Some(packet)) => {
+                        let client_addr = packet.client_addr;
+                        
+                        if let Some(tx) = clients.get(&client_addr) {
+                             if tx.send(packet.data).await.is_err() {
+                                clients.remove(&client_addr);
+                             }
+                        } else {
+                            let (tx, rx) = mpsc::channel(16);
+                            if tx.send(packet.data).await.is_ok() {
+                                let reply_tx_clone = reply_tx.clone();
+                                tokio::spawn(async move {
+                                    debug!(client = %client_addr, "Spawning new UDP client handler");
+                                    if let Err(e) = forward_udp_client_mux(rx, reply_tx_clone, internal_address, source_address, client_addr).await {
+                                        error!(client = %client_addr, "Client handler error: {e}");
+                                    } else {
+                                        debug!(client = %client_addr, "Client handler finished");
+                                    }
+                                });
+                                clients.insert(client_addr, tx);
+                            }
+                        }
+                    },
+                    Ok(None) => {
+                        info!("Host closed vsock stream, shutting down mux proxy.");
+                        break;
+                    }
+                    Err(e) => {
+                        error!("Failed to read from vsock: {e}. Shutting down mux proxy.");
+                        break;
+                    }
+                }
+            },
+
+            Some(reply_packet) = reply_rx.recv() => {
+                if write_event(&mut vsock_write, &reply_packet).await.is_err() {
+                    error!("Failed to write to vsock, shutting down mux proxy.");
+                    break;
+                }
+                if vsock_write.flush().await.is_err() {
+                     error!("Failed to flush vsock, shutting down mux proxy.");
+                    break;
+                }
+            },
+
+            else => {
+                break;
+            }
+        }
     }
+    
+    info!("UDP Mux proxy shut down.");
+    Ok(())
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -7,7 +7,6 @@ use anyhow::{anyhow, Context, Result};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpSocket, TcpStream, UdpSocket},
-    select,
 };
 use tokio_vsock::{VsockAddr, VsockListener, VsockStream};
 
@@ -107,53 +106,9 @@ async fn proxy_tcp(
     mut vsock: VsockStream,
     peer_address: VsockAddr,
     mut stream: TcpStream,
-) -> Result<()> {
-    let (mut vsock_read, mut vsock_write) = vsock.split();
-    let (mut stream_read, mut stream_write) = stream.split();
-
-    let vsock_to_stream = async {
-        let mut buffer = [0u8; 8192];
-        loop {
-            match vsock_read.read(&mut buffer).await {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    if stream_write.write_all(&buffer[..n]).await.is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-        stream_write.shutdown().await
-    };
-
-    let stream_to_vsock = async {
-        let mut buffer = [0u8; 8192];
-        loop {
-            match stream_read.read(&mut buffer).await {
-                Ok(0) => {
-                    debug!("TCP stream closed, shutting down vsock");
-                    break; // EOF - TCP stream closed
-                }
-                Ok(n) => {
-                    if vsock_write.write_all(&buffer[..n]).await.is_err() {
-                        break;
-                    }
-                }
-                Err(e) => {
-                    debug!("Error reading from TCP stream: {:?}", e);
-                    break;
-                }
-            }
-        }
-        vsock_write.shutdown().await
-    };
-
-    select! {
-        _ = vsock_to_stream => {},
-        _ = stream_to_vsock => {},
-    }
-
+) -> anyhow::Result<()> {
+    stream.set_nodelay(true)?;
+    let _ = tokio::io::copy_bidirectional(&mut vsock, &mut stream).await?;
     debug!(peer = peer_address.to_string(), "Proxy operation completed");
     Ok(())
 }

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -126,17 +126,6 @@ async fn process_client(vsock: VsockStream, peer_address: VsockAddr) -> Result<(
     Ok(())
 }
 
-/// Proxy TCP.
-async fn proxy_tcp(
-    mut vsock: VsockStream,
-    peer_address: VsockAddr,
-    mut stream: TcpStream,
-) -> anyhow::Result<()> {
-    stream.set_nodelay(true)?;
-    let _ = tokio::io::copy_bidirectional(&mut vsock, &mut stream).await?;
-    debug!(peer = peer_address.to_string(), "Proxy operation completed");
-    Ok(())
-}
 
 /// Manages a single UDP client's session.
 async fn forward_udp_client_mux(

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,26 +1,23 @@
 //! Host implementation.
-use crate::{write_event, Host, HostRequest, Transport, PacketDirection::{GuestToHost, HostToGuest}};
+use crate::{
+    write_event, read_event, Host, HostRequest, Transport, UdpMuxPacket,
+    PacketDirection::{GuestToHost, HostToGuest}
+};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::{
-    collections::{
-        hash_map::Entry::{Occupied, Vacant},
-        HashMap,
-    },
     net::SocketAddr,
     sync::Arc,
     path::PathBuf,
 };
 use tokio::{
-    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, AsyncRead, AsyncWrite},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, AsyncRead, AsyncWrite, BufWriter},
     net::{TcpListener, TcpStream, UdpSocket, UnixStream},
-    sync::mpsc::{channel, Receiver, Sender},
+    select,
 };
 use tokio_vsock::{VsockAddr, VsockStream};
 use tokio::fs::OpenOptions;
-// host.rs
-use tokio::time::{sleep, Duration}; // add this
-
+use tokio::time::{sleep, Duration};
 
 mod pcap_logger;
 use pcap_logger::PcapLogger;
@@ -79,21 +76,19 @@ pub async fn execute(command: &Host) -> Result<()> {
     info!("processing events");
     loop {
         let mut line = String::new();
-        input
+        
+        let bytes_read = input
             .read_line(&mut line)
             .await
             .context("unable to read new line")?;
 
-        /*
-            // XXX: Dropped support for unspecified external addr
-            let mut x = internal_address.clone();
-            x.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-            x
-        */
-        if line.is_empty() {
-            // EOF: back off so we don’t hot-spin
+        if bytes_read == 0 {
             sleep(Duration::from_millis(200)).await;
             continue
+        }
+        
+        if line.trim().is_empty() {
+            continue;
         }
 
         let Ok(record) = csv_line::from_str::<Entry>(&line) else {
@@ -144,8 +139,8 @@ pub async fn execute(command: &Host) -> Result<()> {
                 let command = command.clone();
                 let pcap_logger = pcap_logger.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = execute_udp_proxy(command, record.internal_address, record.source_address, socket, pcap_logger).await {
-                        error!("unable to execute udp proxy: {e}");
+                    if let Err(e) = execute_udp_mux_proxy(command, record.internal_address, record.source_address, socket, pcap_logger).await {
+                        error!("unable to execute udp mux proxy: {e}");
                     }
                 });
             }
@@ -257,9 +252,8 @@ async fn process_tcp_client(
         source = source_address.to_string(),
         "issuing forwarding request"
     );
-    let e = HostRequest::Forward {
+    let e = HostRequest::ForwardTcp {
         internal_address,
-        transport: Transport::Tcp,
         source_address
     };
     write_event(&mut vsock, &e).await?;
@@ -299,6 +293,8 @@ async fn process_tcp_client(
     };
 
     // Forward data with logging
+    let (mut vsock_read, mut vsock_write) = vsock.socksplit();
+    let (mut stream_read, mut stream_write) = stream.split();
     let mut buf_to_client = vec![0; 4096];
     let mut buf_to_guest = vec![0; 4096];
 
@@ -309,7 +305,7 @@ async fn process_tcp_client(
     loop {
         tokio::select! {
             // Data from vsock to stream (guest to client)
-            bytes_read = vsock.read(&mut buf_to_client) => {
+            bytes_read = vsock_read.read(&mut buf_to_client) => {
                 let bytes_read = bytes_read.context("failed to read from vsock")?;
                 if bytes_read == 0 { break; }
 
@@ -325,13 +321,13 @@ async fn process_tcp_client(
 
 
                 // Forward to client
-                stream.write_all(&buf_to_client[..bytes_read]).await.context("failed to write to stream")?;
+                stream_write.write_all(&buf_to_client[..bytes_read]).await.context("failed to write to stream")?;
                 bytes_from_guest += bytes_read; // Update bytes from guest
                 pcap_logger.log_packet(&buf_to_client[..bytes_read], Transport::Tcp, internal_address, log_client_addr, None, GuestToHost).await;
             }
 
             // Data from stream to vsock (client to guest)
-            bytes_read = stream.read(&mut buf_to_guest) => {
+            bytes_read = stream_read.read(&mut buf_to_guest) => {
                 let bytes_read = bytes_read.context("failed to read from stream")?;
                 if bytes_read == 0 { break; }
 
@@ -343,7 +339,7 @@ async fn process_tcp_client(
 
 
                 // Forward to guest
-                vsock.write_all(&buf_to_guest[..bytes_read]).await.context("failed to write to vsock")?;
+                vsock_write.write_all(&buf_to_guest[..bytes_read]).await.context("failed to write to vsock")?;
                 bytes_to_guest += bytes_read; // Update bytes to guest
                 pcap_logger.log_packet(&buf_to_guest[..bytes_read], Transport::Tcp, log_client_addr, internal_address, None, HostToGuest).await;
             }
@@ -366,8 +362,10 @@ async fn process_tcp_client(
     Ok(())
 }
 
-/// Execute a UDP proxy.
-async fn execute_udp_proxy(
+/// Execute a multiplexed UDP proxy.
+/// This function is spawned ONCE per UDP service.
+/// It handles all external clients over a single vsock stream.
+async fn execute_udp_mux_proxy(
     command: Host,
     internal_address: SocketAddr,
     source_address: SocketAddr,
@@ -379,130 +377,89 @@ async fn execute_udp_proxy(
         external = external_address.to_string(),
         internal = internal_address.to_string(),
         source = source_address.to_string(),
-        "executing udp proxy"
+        "executing multiplexed udp proxy"
     );
 
     let socket = Arc::new(socket);
-    let mut buffer = [0u8; 8192];
-    let mut clients: HashMap<SocketAddr, Sender<Vec<u8>>> = HashMap::new();
-    loop {
-        // Wait for a datagram
-        let (n, client_address) = socket
-            .recv_from(&mut buffer)
-            .await
-            .context("unable to receive client datagram")?;
-        let q = match clients.entry(client_address) {
-            Occupied(e) => e.get().clone(),
-            Vacant(e) => {
-                let command = command.clone();
-                let socket = socket.clone();
-                let (q_tx, q_rx) = channel(16);
-                let pcap_logger = pcap_logger.clone();
-                tokio::spawn(async move {
-                    if let Err(e) =
-                        forward_udp_client(command, socket, client_address, internal_address, source_address, q_rx, Arc::new(pcap_logger))
-                            .await
-                    {
-                        error!(
-                            client = client_address.to_string(),
-                            "unable to forward udp client: {e}"
-                        );
-                    }
-                });
-                e.insert(q_tx).clone()
-            }
-        };
+    let pcap_logger = Arc::new(pcap_logger);
 
-        // Forward to the dedicated client task
-        if let Err(e) = q.send(buffer[..n].to_vec()).await {
-            error!("unable to forward client datagram to task: {e}");
-        }
-    }
-}
+    // Create ONE vsock bridge for this entire service
+    let vsock = connect_to_socket(
+        command.vhost_user_path,
+        command.command_port,
+        command.context_id,
+    )
+    .await?;
+    let (mut vsock_read, vsock_write) = vsock.socksplit();
+    let mut vsock_write = BufWriter::new(vsock_write);
 
-/// Forward a UDP client.
-async fn forward_udp_client(
-    command: Host,
-    socket: Arc<UdpSocket>,
-    client_address: SocketAddr,
-    internal_address: SocketAddr,
-    source_address: SocketAddr,
-    mut queue: Receiver<Vec<u8>>,
-    pcap_logger: Arc<PcapLogger>,
-) -> Result<()> {
-    let external_address = socket.local_addr()?;
-
-    // Create vsock bridge and split it
-    let vsock = connect_to_socket(command.vhost_user_path, command.command_port,
-                                      command.context_id).await?;
-    let (vsock_rx, mut vsock_tx) = vsock.socksplit();
-
-    // Forward data to the guest
-    debug!(
-        external = external_address.to_string(),
-        internal = internal_address.to_string(),
-        source = source_address.to_string(),
-        "issuing open connection request"
-    );
-    let e = HostRequest::Forward {
+    // Send the init request to the guest
+    let e = HostRequest::ForwardUdpMux {
         internal_address,
-        transport: Transport::Udp,
-        source_address: source_address,
+        source_address,
     };
-    write_event(&mut vsock_tx, &e).await?;
+    write_event(&mut vsock_write, &e).await?;
+    vsock_write.flush().await?;
 
-    debug!(
-        client = client_address.to_string(),
-        external = external_address.to_string(),
-        internal = internal_address.to_string(),
-        source = source_address.to_string(),
-        "forwarding udp datagrams"
-    );
+    let mut socket_buf = vec![0u8; 8192];
 
-    // Forward data
-    let pcap_logger_to_client = pcap_logger.clone();
-    tokio::spawn(async move {
-        if let Err(e) = forward_udp_to_client(socket, vsock_rx, client_address, pcap_logger_to_client, internal_address, source_address).await {
-            error!("unable to forward udp to client: {e}");
-        }
-    });
-    while let Some(data) = queue.recv().await {
-        vsock_tx
-            .write_u16(data.len() as _)
-            .await
-            .context("unable to write datagram size")?;
-        vsock_tx
-            .write_all(&data)
-            .await
-            .context("unable to write datagram")?;
-        pcap_logger.log_packet(&data, Transport::Udp, source_address, internal_address, None, HostToGuest).await;
-    }
-    Ok(())
-}
-
-/// Forward UDP to client.
-async fn forward_udp_to_client(
-    socket: Arc<UdpSocket>,
-    mut vsock_rx: Box<dyn AsyncRead + Unpin + Send>,
-    client_address: SocketAddr,
-    pcap_logger: Arc<PcapLogger>,
-    internal_address: SocketAddr,
-    peer_address: SocketAddr
-) -> Result<()> {
-    let mut buffer = [0u8; 8192];
     loop {
-        let n = vsock_rx
-            .read_u16()
-            .await
-            .context("unable to read datagram size")? as _;
-        vsock_rx
-            .read_exact(&mut buffer[..n])
-            .await
-            .context("unable to read datagram")?;
-        socket
-            .send_to(&buffer, &client_address)
-            .await
-            .context("unable to send datagram")?;
-        pcap_logger.log_packet(&buffer[..n], Transport::Udp, internal_address, peer_address, None, GuestToHost).await;
+        select! {
+            // --- Task 1: Guest -> Host -> External Client ---
+            result = read_event::<_, UdpMuxPacket>(&mut vsock_read) => {
+                match result {
+                    Ok(Some(packet)) => {
+                        let client_addr = packet.client_addr;
+                        let data = packet.data;
+                        
+                        pcap_logger.log_packet(&data, Transport::Udp, internal_address, client_addr, None, GuestToHost).await;
+
+                        if let Err(e) = socket.send_to(&data, client_addr).await {
+                            error!(client = %client_addr, "failed to send datagram to external client: {e}");
+                        }
+                    },
+                    Ok(None) => {
+                        info!("Vsock stream closed by guest, shutting down UDP proxy.");
+                        break;
+                    }
+                    Err(e) => {
+                        error!("Failed to read from vsock: {e}. Shutting down UDP proxy.");
+                        break;
+                    }
+                }
+            }
+
+            // --- Task 2: External Client -> Host -> Guest ---
+            result = socket.recv_from(&mut socket_buf) => {
+                 match result {
+                    Ok((n, client_addr)) => {
+                        let data = socket_buf[..n].to_vec();
+
+                        let log_client_addr = SocketAddr::new(source_address.ip(), client_addr.port());
+                        pcap_logger.log_packet(&data, Transport::Udp, log_client_addr, internal_address, None, HostToGuest).await;
+
+                        let packet = UdpMuxPacket {
+                            client_addr,
+                            data,
+                        };
+                        
+                        if let Err(e) = write_event(&mut vsock_write, &packet).await {
+                            error!("Failed to write to vsock: {e}. Shutting down UDP proxy.");
+                            break;
+                        }
+                        if let Err(e) = vsock_write.flush().await {
+                            error!("Failed to flush vsock writer: {e}. Shutting down UDP proxy.");
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        error!("Failed to read from external socket: {e}. Shutting down UDP proxy.");
+                        break;
+                    }
+                }
+            }
+        }
     }
+
+    Ok(())
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -18,6 +18,9 @@ use tokio::{
 };
 use tokio_vsock::{VsockAddr, VsockStream};
 use tokio::fs::OpenOptions;
+// host.rs
+use tokio::time::{sleep, Duration}; // add this
+
 
 mod pcap_logger;
 use pcap_logger::PcapLogger;
@@ -88,6 +91,8 @@ pub async fn execute(command: &Host) -> Result<()> {
             x
         */
         if line.is_empty() {
+            // EOF: back off so we don’t hot-spin
+            sleep(Duration::from_millis(200)).await;
             continue
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,15 +91,31 @@ pub enum GuestRequest {
 /// Host request.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum HostRequest {
-    /// Forward data.
-    Forward {
+    /// Forward a TCP connection.
+    ForwardTcp {
         /// Internal address.
         internal_address: SocketAddr,
-        /// Transport.
-        transport: Transport,
         /// Source address (for spoofing).
         source_address: SocketAddr,
     },
+    /// Start a multiplexed UDP proxy.
+    ForwardUdpMux {
+        /// Internal address.
+        internal_address: SocketAddr,
+        /// Source address (for spoofing).
+        source_address: SocketAddr,
+    },
+}
+
+/// A multiplexed UDP packet.
+/// This is sent over the shared vsock stream in both directions.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UdpMuxPacket {
+    /// The external client's address.
+    pub client_addr: SocketAddr,
+    /// The UDP payload.
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
 }
 
 /// Transport.
@@ -169,6 +185,9 @@ where
         Ok(Err(e)) => return Err(e.into()),
         Err(_) => return Ok(None),
     };
+    if n == 0 {
+        return Ok(None); // Clean EOF
+    }
     let mut buffer = vec![0u8; n as _];
     timeout(
         Duration::from_secs(VSOCK_READ_TIMEOUT_SECS),

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,20 +134,26 @@ pub fn main() -> Result<()> {
         Daemonize::new().start()?;
     }
 
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(async {
-            let result = match conf.command {
-                Command::Guest(ref command) => guest::execute(command).await,
-                Command::Host(ref command) => host::execute(command).await,
-            };
+    let result = match conf.command {
+        Command::Guest(ref command) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()?;
+            rt.block_on(guest::execute(command))
+        }
+        Command::Host(ref command) => {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(host::execute(command))
+        }
+    };
 
-            if let Err(e) = result {
-                error!("{e:?}");
-                ::std::process::exit(1);
-            }
-        });
+    if let Err(e) = result {
+        error!("{e:?}");
+        ::std::process::exit(1);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This PR does the following:
- switches the guest to use a single-threaded tokio engine
- switches the guest to use copy_bidirectional
- adds a sleep in a hot path in the host
- pins our csv to an older version because of rust version restrictions (relevant for MIPS)